### PR TITLE
Disable cache and etags

### DIFF
--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -138,7 +138,11 @@ class NbconvertFileHandler(IPythonHandler):
             self.set_header('Content-Type',
                             '%s; charset=utf-8' % exporter.output_mimetype)
 
+        self.set_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
         self.finish(output)
+
+    def compute_etag(self):
+        return None
 
 class NbconvertPostHandler(IPythonHandler):
     SUPPORTED_METHODS = ('POST',)


### PR DESCRIPTION
https://github.com/jupyter/notebook/issues/3251

The handler that processes a download request did not have a `compute_etag` override, which causes the `etag_header` to be set.  This PR adds a overrides the `computer_etag` method, and adds a cache-control header to e safe.

Useful links:
http://www.tornadoweb.org/en/stable/_modules/tornado/web.html#RequestHandler.finish
http://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.check_etag_header